### PR TITLE
Change h1_name variable

### DIFF
--- a/by_state.py
+++ b/by_state.py
@@ -126,14 +126,14 @@ def make_territories_ref_list(territory_key, territories):
     d = {'country': 'countries', 'state': 'states'}
     if territory_key == 'state':
         path = 'states_list.html'
-        h1_name = 'States'
+        page_title = 'States'
     else:
         path = 'countries_list.html'
-        h1_name = 'Countries'
+        page_title = 'Countries'
     t = ENV.get_template('territories_ref.html')
     t =  t.render(title = 'By {k}'.format(k = territory_key), 
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            h1_name = h1_name,
+            page_title = page_title,
             territories = [(d[territory_key] + '/' + common.tidy_name(x) + '.html', x) for x in territories]
             )
     if not os.path.isdir('html_temp'):

--- a/make_index_404.py
+++ b/make_index_404.py
@@ -15,7 +15,7 @@ def make_index():
     html = t.render(title = 'home', 
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             site_name = 'Covid 19',
-            h1_name = 'Covid 19',
+            page_title = 'Covid 19',
             )
     with open(os.path.join('html_temp', 'index.html'), 'w') as write_obj:
         write_obj.write(html)
@@ -25,7 +25,7 @@ def make_404():
     html = t.render(title = 'home', 
             date = datetime.datetime.now(),
             site_name = 'Covid 19',
-            h1_name = 'Covid 19',
+            page_title = 'Covid 19',
             )
     with open(os.path.join('html_temp', '404.html'), 'w') as write_obj:
         write_obj.write(html)

--- a/make_territories.py
+++ b/make_territories.py
@@ -134,14 +134,14 @@ def make_territories_ref_list(territory_key, territories):
     d = {'country': 'countries', 'state': 'states'}
     if territory_key == 'state':
         path = 'states_list.html'
-        h1_name = 'States'
+        page_title = 'States'
     else:
         path = 'countries_list.html'
-        h1_name = 'Countries'
+        page_title = 'Countries'
     t = ENV.get_template('territories_ref.html')
     t =  t.render(title = 'By {k}'.format(k = territory_key), 
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            h1_name = h1_name,
+            page_title = page_title,
             territories = [(d[territory_key] + '/' + common.tidy_name(x) + '.html', x) for x in territories]
             )
     if not os.path.isdir('html_temp'):

--- a/templates/404.html
+++ b/templates/404.html
@@ -2,7 +2,7 @@
 {% block content %}
         <header>
 			<div class="siteName">{{site_name}}</div>
-			<h1>{{h1_name}}</h1>
+			<h1>{{page_title}}</h1>
 			<p>updated: {{date}}</p>
 			{% include "nav.html" %}
         </header>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
         <header>
 			<div class="siteName">{{site_name}}</div>
-			<h1>{{h1_name}}</h1>
+			<h1>{{page_title}}</h1>
 			<p>updated: {{date}}</p>
 			{% include "nav.html" %}
         </header>

--- a/templates/rt_growth.html
+++ b/templates/rt_growth.html
@@ -2,7 +2,7 @@
 {% block content %}
         <header>
 			<div class="siteName">{{site_name}}</div>
-			<h1>{{h1_name}}</h1>
+			<h1>{{page_title}}</h1>
 			<p>updated: {{date}}</p>
 			{% include "nav.html" %}
         </header>

--- a/templates/territories_ref.html
+++ b/templates/territories_ref.html
@@ -3,7 +3,7 @@
 <h1>{{title}}</h1>
 	<p>updated: {{date}}</p>
 	<div class="siteName">{{site_name}}</div>
-	<h1>{{h1_name}}</h1>
+	<h1>{{page_title}}</h1>
 	{% include "nav.html" %}
 	<main>
 	{% for t in territories %}

--- a/templates/us_rates.html
+++ b/templates/us_rates.html
@@ -2,7 +2,7 @@
 {% block content %}
         <header>
 			<div class="siteName">{{site_name}}</div>
-			<h1>{{h1_name}}</h1>
+			<h1>{{page_title}}</h1>
 			<p>updated: {{date}}</p>
 			{% include "nav.html" %}
         </header>

--- a/templates/wa.html
+++ b/templates/wa.html
@@ -2,7 +2,7 @@
 {% block content %}
         <header>
 			<div class="siteName">{{site_name}}</div>
-			<h1>{{h1_name}}</h1>
+			<h1>{{page_title}}</h1>
 			<p>updated: {{date}}</p>
 			{% include "nav.html" %}
         </header>

--- a/us_states_rates.py
+++ b/us_states_rates.py
@@ -98,7 +98,7 @@ def get_html(script, div, the_type):
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             div = div,
             site_name = site_name,
-            h1_name = title,
+            page_title = title,
             )
 def main():
     if not os.path.isdir('html_temp'):

--- a/us_states_rt.py
+++ b/us_states_rt.py
@@ -114,15 +114,15 @@ def get_html(script, div, date, title, the_type ):
     """
     t = ENV.get_template('rt_growth.html')
     if the_type == 'deaths':
-        h1_name = 'States Rate of Growth Deaths'
+        page_title = 'States Rate of Growth Deaths'
     elif the_type == 'cases':
-        h1_name = 'States Rate of Growth Infections'
+        page_title = 'States Rate of Growth Infections'
     return t.render(title = title, 
             script =  script,
             date = date,
             site_name = 'Covid 19 Data: Cases, Deaths, and Changes by State',
             div = div,
-            h1_name = h1_name,
+            page_title = page_title,
             )
 
 def make_rt_html(window = 3):

--- a/washington_state.py
+++ b/washington_state.py
@@ -92,7 +92,7 @@ def get_html(script, div, date, title):
             date = date,
             site_name = 'Covid 19 Data: Cases, Deaths, and Changes by State',
             div = div,
-            h1_name = 'States Rate of Growth Deaths',
+            page_title = 'States Rate of Growth Deaths',
             )
 
 def make_washington_graphs():


### PR DESCRIPTION
Changes h1_name to page_title to account for other uses of top level `<h1>` element content.

Fixes #18.