### PR TITLE
Adds jquery link and sri attribute to bokeh link in `<head>`

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,7 +6,8 @@
     <title>{% block title %}{{ page_title }} || {{ website.name }}{% endblock title %}</title>
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/styles/site.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bokeh/2.0.2/bokeh.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bokeh/2.0.2/bokeh.min.js" integrity="sha256-q6H2tiCn/WI6/yUscC8yNCGup3XM1lizbZckx5edIl0=" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs=" crossorigin="anonymous"></script>
     {{script|safe}}
   </head>
 


### PR DESCRIPTION
Adds jquery `<link>` to base.html`<head>`, which we can use going forward for dom traversal. The link is to the minified slim version of jquery. Any ajax stuff will likely be handled by React.js or something like it.

Adds sri attributes to cloudfare cdn `<link>` for security reasons.

Fixes issues #22 and #23.