### PR TITLE
Fixes data table pages

### DIFF
--- a/data_table.py
+++ b/data_table.py
@@ -147,9 +147,12 @@ def make_state_tables(verbose = False, window = None):
 
 def get_html(header, body, caption):
     t = ENV.get_template('data_table.j2')
-    return t.render(table_head = header, 
+    return t.render(page_title = caption,
+            date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            table_head = header, 
             table_body =  body,
-            caption = caption
+            caption = caption,
+            page_class_attr = ["dataTable"],
             )
 
 def make_html_table(path):
@@ -199,9 +202,9 @@ def make_html_table(path):
             body =data, caption = 'Deaths')
     html_cases = get_html(header = header, 
             body =data_cases, caption= 'Cases')
-    with open(os.path.join('html_temp', 'table_data_deaths.html'), 'w') as write_obj:
+    with open(os.path.join('html_temp', 'table-data-deaths'), 'w') as write_obj:
         write_obj.write(html_deaths)
-    with open(os.path.join('html_temp', 'table_data_cases.html'), 'w') as write_obj:
+    with open(os.path.join('html_temp', 'table-data-cases'), 'w') as write_obj:
         write_obj.write(html_cases)
 
 

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -6,6 +6,7 @@
     <title>{% block title %}{% endblock title %}</title>
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/styles/site.css">
+    {% block stylesheets -%}{% endblock stylesheets %}
 
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs=" crossorigin="anonymous"></script>
     {% block scripts %}

--- a/templates/data_table.j2
+++ b/templates/data_table.j2
@@ -1,67 +1,53 @@
-<html lang="en">
-	<head>
-    	<meta charset="utf-8">
-		<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
+{% extends "data.j2" %}
 
+{# pages containing data tables #}
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
-	<style>
-		.data-number{
-		 text-align:right;
-		}
-		.data-state{
-			text-align:left;
-		}
-		.data-header-state{
-			text-align:left;
-		}
-		.data-header-number{
-			text-align:right;
-		}
-		caption{
-			font-size:18;
-		}
-	</style>
+{%- block stylesheets -%}
+		<link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
+{%- endblock stylesheets -%}
 
-	</head>
-	<body>
-	<script>
-		$(document).ready(function() {
-    $('#data').DataTable( {
-        "order": [[ 0, "asc" ]],
-		 "pageLength":10 
-    } );
-} );
+{% block scripts %}
+    <script src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
+
+    <script>
+      $(document).ready(function() {
+        $('table').DataTable( {
+          "order": [[ 0, "asc" ]],
+          "pageLength":10 
+        } );
+      } );
 	</script>
-	<table id="data" class="display" style="width:100%">
-		<caption>{{caption}}</caption>
-        <thead>
-            <tr>
-				{% for item in table_head %}
-					{% if loop.index == 1 %}
-						<th class = 'data-header-state'>{{item}}</th>
-					{% else %}
-						<th class = 'data-header-number'>{{item}}</th>
-					{% endif %}
-				{% endfor %}
 
+{% endblock scripts %}
+
+{% block content %}
+
+      <table class="display">
+
+        <caption>{{caption}}</caption>
+
+          <thead>
+            <tr>
+  				{% for item in table_head %}
+              <th>{{item}}</th>
+  				{%- endfor %}
             </tr>
-        </thead>
-        <tbody>
-			{% for row in table_body %}
-				<tr>
-					{% for cell in row %}
-						{% if loop.index == 1 %}
-							<td class = 'data-state'>{{cell}}</td>
-						{% else %}
-							<td class = 'data-number'>{{cell}}</td>
-						{% endif %}
-				    {% endfor %}
-				</tr>
-			{% endfor %}
-		</tbody>
-	</table>
- </body>
-</html>
- 
+          </thead>
+
+          <tbody>
+  			{% for row in table_body %}
+            <tr>
+  					{% for cell in row -%}
+						  {%- if loop.index == 1 -%}
+              <th>{{cell}}</th>
+              {% else -%}
+              <td>{{cell}}</td>
+              {% endif -%}
+  				  {%- endfor -%}
+            </tr>
+  			{% endfor %}
+          </tbody>
+
+      </table>
+
+{% endblock content %}

--- a/templates/nav.j2
+++ b/templates/nav.j2
@@ -1,14 +1,12 @@
       <nav>
-      	<ul>
-      		<li><a href="/">Home</a></li>
-      		<li><a href="states-deaths">Deaths over Time</a></li>
-      		<li><a href="states-cases">Cases over Time</a></li>
-      		<li><a href="/states/">States</a></li>
-      		<li><a href="/countries/">Countries</a></li>
-      		<li><a href="sweden-vs-other">Sweden Compared to Other</a></li>
-          <li><a href="table_data_deaths.html">Table Data Deaths</a></li>
-		      <li><a href="table_data_cases.html">Table Data Cases</a></li>
-
-      	</ul>
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="states-deaths">Deaths over Time</a></li>
+          <li><a href="states-cases">Cases over Time</a></li>
+          <li><a href="/states/">States</a></li>
+          <li><a href="/countries/">Countries</a></li>
+          <li><a href="sweden-vs-other">Sweden Compared to Other</a></li>
+          <li><a href="table-data-deaths">Table Data Deaths</a></li>
+          <li><a href="table-data-cases">Table Data Cases</a></li>        
+        </ul>
       </nav>
-

--- a/templates/styles/site.css
+++ b/templates/styles/site.css
@@ -59,3 +59,24 @@ ul > li > a {
 .regionList > ul > li {
   margin-bottom: .5em;
 }
+
+caption {
+  font-size: 120%;
+}
+
+table > thead > tr > th + th {
+  text-align: right;
+}
+
+table > thead > tr > th:first-child {
+  text-align: left;
+}
+
+table > tbody > tr > th {
+  font-weight: normal;
+  text-align: left;
+}
+
+table > tbody > tr > td {
+  text-align: right;
+}


### PR DESCRIPTION
Changes data_table.j2 to extend data.j2 which reuses markup and keeps site consistent. Simplifies markup for data tables.

Adds stylesheet block to base.j2. Moves style rules from page’s style element to /styles/site.css.

Changes data_table.py to supply page_title and date variable.

Changes urls and filenames to drop .html suffix/extension, and replaces underscore with hyphen.