### PR TITLE
Fix empty h1

### DIFF
--- a/by_state.py
+++ b/by_state.py
@@ -158,7 +158,7 @@ def make_territories_ref_list(territory_key, territories):
         path = 'countries/index.html'
         page_title = 'Countries'
     t = ENV.get_template('territories_ref.j2')
-    t =  t.render(title = 'By {k}'.format(k = territory_key), 
+    t =  t.render(page_title = 'By {k}'.format(k = territory_key),
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             page_title = page_title,
             page_class_attr = ["regionList", territory_key.lower()],

--- a/by_state.py
+++ b/by_state.py
@@ -158,9 +158,8 @@ def make_territories_ref_list(territory_key, territories):
         path = 'countries/index.html'
         page_title = 'Countries'
     t = ENV.get_template('territories_ref.j2')
-    t =  t.render(page_title = 'By {k}'.format(k = territory_key),
+    t =  t.render(page_title = page_title,
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            page_title = page_title,
             page_class_attr = ["regionList", territory_key.lower()],
             territories = [(common.make_hyphenated(x), x) for x in territories]
             )

--- a/make_about.py
+++ b/make_about.py
@@ -18,9 +18,8 @@ ENV = Environment(
 
 def make_about():
     t = ENV.get_template('about.j2')
-    html = t.render(title = 'about', 
+    html = t.render(page_title = 'About This Site',
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            page_title = 'About this site',
             page_class_attr = ["aboutSite"],
             contributors = contributors
             )

--- a/make_index_404.py
+++ b/make_index_404.py
@@ -23,7 +23,7 @@ def make_404():
     t = ENV.get_template('404.j2')
     html = t.render(title = 'home', 
             date = datetime.datetime.now(),
-            page_title = 'Not Found',
+            page_title = 'Error',
             page_class_attr = ["error"],
             )
     with open(os.path.join('html_temp', '404.html'), 'w') as write_obj:

--- a/make_index_404.py
+++ b/make_index_404.py
@@ -12,8 +12,7 @@ ENV = Environment(
 
 def make_index():
     t = ENV.get_template('index.j2')
-    html = t.render(title = 'home',
-            date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+    html = t.render(date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             page_class_attr = ["home"],
             )
     with open(os.path.join('html_temp', 'index.html'), 'w') as write_obj:
@@ -21,9 +20,7 @@ def make_index():
 
 def make_404():
     t = ENV.get_template('404.j2')
-    html = t.render(title = 'home', 
-            date = datetime.datetime.now(),
-            page_title = 'Error',
+    html = t.render(page_title = 'Error',
             page_class_attr = ["error"],
             )
     with open(os.path.join('html_temp', '404.html'), 'w') as write_obj:
@@ -33,4 +30,3 @@ def make_404():
 if __name__ == '__main__':
     make_index()
     make_404()
-

--- a/make_territories.py
+++ b/make_territories.py
@@ -62,7 +62,7 @@ def get_html(territory, script, div, death_ro, death_double_rate,
     if cases_ro == None:
         cases_ro = 0
     t = ENV.get_template('countries.j2')
-    return t.render(title = territory, 
+    return t.render(page_title = territory,
             script = script,
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             page_class_attr = ["country", "graph", common.make_hyphenated(territory)],

--- a/sweden.py
+++ b/sweden.py
@@ -46,8 +46,7 @@ def get_html(date, script, div, window):
     Create the HTML 
     """
     t = ENV.get_template('sweden_vs.j2')
-    return t.render(title = 'Sweden Vs. Other',
-            page_title = "Sweden Vs. Other",
+    return t.render(page_title = "Sweden Vs. Other",
             script = script,
             date = date,
             page_class_attr = ["swedenComparison"],

--- a/sweden.py
+++ b/sweden.py
@@ -46,8 +46,9 @@ def get_html(date, script, div, window):
     Create the HTML 
     """
     t = ENV.get_template('sweden_vs.j2')
-    return t.render(title = 'Sweden Vs. Other', 
-            script =  script,
+    return t.render(title = 'Sweden Vs. Other',
+            page_title = "Sweden Vs. Other",
+            script = script,
             date = date,
             page_class_attr = ["swedenComparison"],
             div = div,

--- a/templates/404.j2
+++ b/templates/404.j2
@@ -2,20 +2,14 @@
 
 {# error page #}
 
-{% block title %}Error || {{ website_title }}{% endblock title %}
-
 {%- block scripts -%}{% endblock scripts %}
 
-{% block page_header %}
-      <div class="siteNameSlogan">
-        {{ website_title }}: {{ website_slogan }}
-      </div>
-      {{ super() }}
-      <h1>Error</h1>
-{% endblock page_header %}
+{% block title %}Error || {{ site_name }}{% endblock title %}
+
+{%- block last_updated -%}{%- endblock last_updated -%}
 
 {% block content %}
         <p>
-          The requested page (or image, or file, or...) was not found.
+          There was an error retrieving the page/resource you requested.
         </p>
 {% endblock %}

--- a/templates/about.j2
+++ b/templates/about.j2
@@ -1,10 +1,10 @@
-{% extends "data.j2" %}
+{% extends "base.j2" %}
 
 {# about the site page to show links to contributors' github pages #}
 
 {% block content %}
       <p>
-        {{ website_title }} is a collaborative project with these contributors:
+        {{ site_title }} is a collaborative project with these contributors:
       </p>
 
       <ul>

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -1,15 +1,16 @@
-{%- set website_title = "Covid-19 Data" -%}
-{%- set website_slogan = "Trends in Number and Rates of Infections" -%}
+{%- set site_name = "Covid-19 Data" -%}
+{%- set site_slogan = "Trends in Number and Rates of Infections" -%}
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>{% block title %}{% endblock title %}</title>
+    <title>{% block title %}{{ page_title }} || {{ site_name }}{% endblock title %}</title>
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/styles/site.css">
-    {% block stylesheets -%}{% endblock stylesheets %}
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;0,900;1,300;1,400;1,500;1,700;1,900&amp;family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&amp;display=swap">
+    {% block stylesheets %}{% endblock stylesheets %}
 
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs=" crossorigin="anonymous"></script>
-    {% block scripts %}
+    {%- block scripts %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bokeh/2.0.2/bokeh.min.js" integrity="sha256-q6H2tiCn/WI6/yUscC8yNCGup3XM1lizbZckx5edIl0=" crossorigin="anonymous"></script>
     {{script|safe}}
     {% endblock scripts %}
@@ -18,9 +19,16 @@
   <body>
 
     <header>
-    {% block page_header %}
-      {%- include "nav.j2" -%}
-    {% endblock page_header %}
+
+    {%- block page_header %}
+      <div class="siteNameSlogan">
+        {% block site_name %}<div class="siteName">{{ site_name }}</div>{% endblock site_name %}
+        <span class="siteSlogan">{{ site_slogan }}</span>
+      </div>
+      {% include "nav.j2" %}
+			{% block page_h1 %}<h1>{{ page_title }}</h1>{% endblock page_h1 %}
+      {% block last_updated %}<p>Last updated: {{date}}</p>{% endblock last_updated %}
+    {%- endblock page_header %}
     </header>
 
     <main class="{{ page_class_attr|join(' ') }}">
@@ -31,7 +39,7 @@
     <footer>
       <address>
       	<p>
-        	This page is part of a
+        	This page is part of {{ site_name }}, a
           {% block about_link %}<a href="/about">collaborative project</a>{% endblock about_link %}
         	created by <a href="https://github.com/paulhtremblay">Henry Tremblay</a>
         </p>

--- a/templates/data.j2
+++ b/templates/data.j2
@@ -1,17 +1,6 @@
-{% extends "base.j2" %} {# for all pages that show Covid data/charts/etc. #}
+{% extends "base.j2" %}
 
-{# parent of all data pages (basically, all but home and error pages) #}
-
-{% block title %}{{ page_title }} || {{ website_title }}{% endblock title %}
-
-{% block page_header %}
-      <div class="siteNameSlogan">
-        {{ website_title }}: {{ website_slogan }}
-      </div>
-      {{ super() }}
-			<h1>{{ page_title }}</h1>
-      <p>Last updated: {{date}}</p>
-{% endblock page_header %}
+{# for all data pages #}
 
 {% block content %}
       {{div|safe}}

--- a/templates/data_table.j2
+++ b/templates/data_table.j2
@@ -22,7 +22,7 @@
 
 {% block content %}
 
-      <table class="display">
+      <table class="covidData display">
 
         <caption>{{caption}}</caption>
 

--- a/templates/index.j2
+++ b/templates/index.j2
@@ -2,17 +2,26 @@
 
 {# website home page #}
 
-{% block title %}{{ website_title }}: {{ website_slogan }}{% endblock %}
+{% block title %}{{ site_name }} || {{ site_slogan }}{% endblock title %}
 
-{% block page_header %}
-        <h1 class="siteNameSlogan">{{ website_title }}: {{ website_slogan }}</h1>
-        {{ super() }}
-{% endblock page_header %}
+{% block site_name %}<h1 class="siteName">{{ site_name }}</h1>{% endblock site_name %}
+
+{%- block page_h1 -%}{%- endblock page_h1 -%}
+{%- block last_updated -%}{%- endblock last_updated -%}
 
 {% block content %}
+      <article>
+        <header>
+          <h1>{{ page_title }}</h1>
+          <p>Last updated: {{date}}</p>
+        </header>
+
+        {{div|safe}}
+
+      </article>
+
       <p>
         Graphs showing trends in Covid-19 infection, deaths, and rates
         in the <abbr title="United States">U.S.</abbr> and world.
       </p>
 {% endblock content %}
-

--- a/templates/nav.j2
+++ b/templates/nav.j2
@@ -1,12 +1,12 @@
 <nav>
         <ul>
           <li><a href="/">Home</a></li>
-          <li><a href="states-deaths">Deaths over Time</a></li>
-          <li><a href="states-cases">Cases over Time</a></li>
+          <li><a href="/states-deaths">Deaths over Time</a></li>
+          <li><a href="/states-cases">Cases over Time</a></li>
           <li><a href="/states/">States</a></li>
           <li><a href="/countries/">Countries</a></li>
-          <li><a href="sweden-vs-other">Sweden Compared to Other</a></li>
-          <li><a href="table-data-deaths">Table Data Deaths</a></li>
-          <li><a href="table-data-cases">Table Data Cases</a></li>        
+          <li><a href="/sweden-vs-other">Sweden Compared to Other</a></li>
+          <li><a href="/table-data-deaths">Table Data Deaths</a></li>
+          <li><a href="/table-data-cases">Table Data Cases</a></li>        
         </ul>
       </nav>

--- a/templates/nav.j2
+++ b/templates/nav.j2
@@ -1,4 +1,4 @@
-      <nav>
+<nav>
         <ul>
           <li><a href="/">Home</a></li>
           <li><a href="states-deaths">Deaths over Time</a></li>

--- a/templates/styles/site.css
+++ b/templates/styles/site.css
@@ -1,14 +1,74 @@
 /* site wide styles for covid 19 data site */
 
+html {
+  --bloodRed: rgb(155, 17, 28);
+  --pageBackground: #fff;
+  --bleedPadding: .5rem;
+  --bleedMargin: -.5rem;
+}
+
+header {
+  --txtColor: #ffdc00;
+}
+
+body {
+  font-family: Roboto, Helvetica, Arial, sans-serif;
+  margin-top: 0;
+  padding-top: 0;
+}
+
+body > header > nav,
 .siteNameSlogan {
-  font-size: 200%;
-  font-weight: bold;
-  margin-top: .68em;
+  margin-left: var(--bleedMargin);
+  margin-right: var(--bleedMargin);
+  padding-left: var(--bleedPadding);
+  padding-right: var(--bleedPadding);
+}
+
+
+h1 {
+  color: var(--bloodRed);
+  background-color: var(--pageBackground);
+}
+
+h1.siteName,
+nav,
+.siteNameSlogan {
+  color: var(--txtColor);
+  background-color: var(--bloodRed);
+}
+
+.siteNameSlogan {
+  padding-top: .68em;
+  padding-bottom: .66em;
+}
+
+nav {
+  padding-top: 1px;
+  padding-bottom: .1em;
+  font-size: 110%;
 }
 
 a:hover {
   color: white;
   background-color: blue;
+  text-decoration: none;
+}
+
+.home > article > h1,
+.siteName, .siteSlogan {
+  font-size: 200%;
+  font-weight: bold;
+}
+
+nav > ul > li > a {
+  color: var(--grayColor);
+  background-color: var(--bloodRed);
+}
+
+nav > ul > li > a:hover {
+  color: #ffdc00;
+  background-color: var(--bloodRed);
 }
 
 ul > li > a {
@@ -19,6 +79,10 @@ ul > li > a {
 
   nav > ul > li {
     margin-bottom: .5em;
+  }
+
+  .siteSlogan {
+    display: none;
   }
 
 }
@@ -35,6 +99,15 @@ ul > li > a {
 
   nav > ul > li {
     display: inline-block;
+  }
+
+  .siteName,
+  .siteSlogan {
+    display: inline;
+  }
+
+  .siteName:after {
+    content: ": ";
   }
 
 }
@@ -60,23 +133,29 @@ ul > li > a {
   margin-bottom: .5em;
 }
 
+td {
+  font-family: "Roboto Mono", monospace;
+  padding-right: 2em !important;
+}
+
 caption {
   font-size: 120%;
 }
 
-table > thead > tr > th + th {
+table.covidData > thead > tr > th + th {
   text-align: right;
 }
 
-table > thead > tr > th:first-child {
+table.covidData > thead > tr > th:first-child {
   text-align: left;
 }
 
-table > tbody > tr > th {
+table.covidData > tbody > tr > th {
   font-weight: normal;
   text-align: left;
 }
 
-table > tbody > tr > td {
+table.covidData > tbody > tr > td {
   text-align: right;
 }
+

--- a/templates/sweden_vs.j2
+++ b/templates/sweden_vs.j2
@@ -1,4 +1,4 @@
-{% extends "base.j2" %}
+{% extends "data.j2" %}
 
 {% block content %}
   <h2>{{graph_title}}</h2>

--- a/us_states_rates.py
+++ b/us_states_rates.py
@@ -92,12 +92,11 @@ def get_html(script, div, the_type):
     elif the_type == 'cases':
         title = 'Growth of rates of cases'
     t = ENV.get_template('data.j2')
-    return t.render(title = title, 
+    return t.render(page_title = title,
             script =  script,
             date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             page_class_attr = ["deathRateGrowth"],
             div = div,
-            page_title = title,
             )
 def main():
     if not os.path.isdir('html_temp'):

--- a/us_states_rt.py
+++ b/us_states_rt.py
@@ -117,12 +117,11 @@ def get_html(script, div, date, title, the_type ):
         page_title = 'States Rate of Growth Deaths'
     elif the_type == 'cases':
         page_title = 'States Rate of Growth Infections'
-    return t.render(title = title, 
+    return t.render(page_title = page_title,
             script =  script,
             date = date,
             page_class_attr = ["infectionGrowthRate"],
             div = div,
-            page_title = page_title,
             )
 
 def make_rt_html(window = 3):

--- a/washington_state.py
+++ b/washington_state.py
@@ -87,11 +87,10 @@ def get_html(script, div, date, title):
     Create the HTML for each state
     """
     t = ENV.get_template('data.j2')
-    return t.render(title = title, 
+    return t.render(page_title = title,
             script =  script,
             date = date,
             div = div,
-            page_title = 'States Rate of Growth Deaths',
             )
 
 def make_washington_graphs():


### PR DESCRIPTION
The make*.py files often use title as a variable in the call the render (after get_template). I think this is old code. The templates are looking for page_title, so many pages have empty `<h1>` elements. This commit fixes that. But if the title variable is doing something else, let me know and I'll make a different fix to the missing `<h1>` problem.