### PR TITLE
Move nav links

### DIFF
--- a/by_counties.py
+++ b/by_counties.py
@@ -24,6 +24,7 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
 
 def get_county_data():
     path = common.get_data_path(os.path.abspath(os.path.dirname(__file__)), 'seven_day_county.csv')

--- a/by_counties.py
+++ b/by_counties.py
@@ -55,29 +55,28 @@ def make_county_ref_list(states):
     t =  t.render(title = 'By County',
             page_title = page_title,
             page_class_attr = ["regionList", "state", "county"],
-            territories = [(slugify(x), x) for x in states]
+            territories = states
             )
     if not os.path.isdir('html_temp'):
         os.mkdir('html_temp')
     with open(os.path.join('html_temp', path), 'w') as write_obj:
         write_obj.write(t)
 
-def get_html(state, script, div, the_type):
+def get_html(state, script, div, data_type):
     """
     Create the HTML for each state
     """
-    if the_type == 'Deaths':
-        link_name = 'Cases'
-        link = '{state}-{the_type}'.format(state = slugify(state), the_type = 'cases')
+    if data_type == 'Deaths':
+        other_type = 'Cases'
     else:
-        link_name = 'Deaths'
-        link = '{state}-{the_type}'.format(state = slugify(state), the_type = 'deaths')
+        other_type = 'Deaths'
     t = ENV.get_template('counties.j2')
-    return t.render(page_title = state + " " + the_type,
+    return t.render(page_title = state + " " + data_type + " by County",
             script =  script,
             div = div,
-            link = link,
-            link_name = link_name,
+            state = state,
+            data_type = data_type,
+            other_type = other_type,
             )
 
 def pre_graphs(state, df, sort_by = 'adjusted', key = 'new_deaths'):
@@ -136,14 +135,14 @@ def do_counties():
     title = {'deaths':'Deaths', 'cases': 'Cases'}
     keys = {'deaths': 'new_deaths', 'cases':'new_cases'}
     dir_path = make_counties_dir('county')
-    for the_type in ['deaths', 'cases']:
+    for data_type in ['deaths', 'cases']:
         for state in states:
-            grid = state_counties(df, state, key=keys[the_type])
+            grid = state_counties(df, state, key=keys[data_type])
             script, div = components(grid)
-            html = get_html(state=state, script=script, div=div, the_type=title[the_type])
+            html = get_html(state=state, script=script, div=div, data_type=title[data_type])
             with open(os.path.join(dir_path,
-                    '{state}-{the_type}'.format(state=common.slugify(state),
-                    the_type=the_type)), 'w') as write_obj:
+                    '{state}-{data_type}'.format(state=common.slugify(state),
+                    data_type=data_type)), 'w') as write_obj:
                 write_obj.write(html)
     make_county_ref_list(states)
 

--- a/by_state.py
+++ b/by_state.py
@@ -164,7 +164,7 @@ def make_territories_ref_list(territory_key, territories):
     t = ENV.get_template('territories_ref.j2')
     t =  t.render(page_title = page_title,
             page_class_attr = ["regionList", territory_key.lower()],
-            territories = [(slugify(x), x) for x in territories]
+            territories = territories
             )
     if not os.path.isdir('html_temp'):
         os.mkdir('html_temp')

--- a/by_state.py
+++ b/by_state.py
@@ -31,6 +31,8 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
+
 def get_state_pop():
     path = common.get_data_path(os.path.abspath(os.path.dirname(__file__)), 'states_population.csv')
     d = {}

--- a/by_state.py
+++ b/by_state.py
@@ -101,7 +101,7 @@ def get_html(date, territory, script, div, curr_death, last_week_deaths,
     sig_prev = ''
     if p_last_week > .1:
         sig_prev = '(not significant change from previous)'
-    t = ENV.get_template('countries.j2')
+    t = ENV.get_template('states.j2')
     return t.render(page_title = territory,
             script =  script,
             date = date,
@@ -161,7 +161,7 @@ def make_territories_ref_list(territory_key, territories):
     else:
         path = 'countries/index.html'
         page_title = 'Countries'
-    t = ENV.get_template('territories_ref.j2')
+    t = ENV.get_template('states_ref.j2')
     t =  t.render(page_title = page_title,
             page_class_attr = ["regionList", territory_key.lower()],
             territories = territories

--- a/data_table.py
+++ b/data_table.py
@@ -8,6 +8,7 @@ import pandas as pd
 import numpy as np
 import csv
 
+from slugify import slugify
 
 from jinja2 import Environment, select_autoescape, FileSystemLoader
 
@@ -23,6 +24,7 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
 
 def get_state_pop():
     path = common.get_data_path(os.path.abspath(os.path.dirname(__file__)), 'states_population.csv')

--- a/data_table.py
+++ b/data_table.py
@@ -1,6 +1,7 @@
 import datetime
 import math
 import os
+import pathlib
 import pprint
 pp = pprint.PrettyPrinter(indent = 4)
 from google.cloud import bigquery
@@ -101,8 +102,7 @@ def make_state_tables(verbose = False, window = None):
     totals = get_totals()
     if not window:
         window = int(variables.values['by_state_window'])
-    if not os.path.isdir('html_temp'):
-        os.mkdir('html_temp')
+    pathlib.Path('html_temp/states').mkdir(parents=True, exist_ok=True)
     df_day = get_state_data_day()
     for state in set(df_day['state']):
         if verbose:
@@ -179,7 +179,7 @@ def make_html_table(path):
                 cases_mil = round(float(row['total_cases_per_million']))
             except ValueError:
                 cases_mil = 0
-            data.append([row['state'], 
+            data.append([row['state'],
                 round(float(row['current_week_mean'])),
                 row['current_week_per_million'],
                 round(float(row['last_week_mean'])),
@@ -189,7 +189,7 @@ def make_html_table(path):
                 row['total_deaths'],
                 deaths_mil,
                 ])
-            data_cases.append([row['state'], 
+            data_cases.append([ row['state'],
                 round(float(row['current_week_cases_mean'])),
                 row['current_week_cases_per_million'],
                 round(float(row['last_week_cases_mean'])),
@@ -201,13 +201,13 @@ def make_html_table(path):
                 ])
     header =['state', 'current week mean', 'per million', 'last week mean',
             'per million', 'change', 'significant', 'total', 'per million']
-    html_deaths = get_html(header = header, 
+    html_deaths = get_html(header = header,
             body =data, caption = 'Deaths')
-    html_cases = get_html(header = header, 
+    html_cases = get_html(header = header,
             body =data_cases, caption= 'Cases')
-    with open(os.path.join('html_temp', 'table-data-deaths'), 'w') as write_obj:
+    with open(os.path.join('html_temp', 'states', 'table-deaths'), 'w') as write_obj:
         write_obj.write(html_deaths)
-    with open(os.path.join('html_temp', 'table-data-cases'), 'w') as write_obj:
+    with open(os.path.join('html_temp', 'states', 'table-cases'), 'w') as write_obj:
         write_obj.write(html_cases)
 
 

--- a/make_about.py
+++ b/make_about.py
@@ -5,6 +5,8 @@ import json
 
 from jinja2 import Environment, select_autoescape, FileSystemLoader
 
+from slugify import slugify
+
 with urllib.request.urlopen("https://api.github.com/repos/paulhtremblay/covid19/contributors") as url:
     contributors = json.loads(url.read().decode())
 
@@ -16,6 +18,7 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
 
 def make_about():
     t = ENV.get_template('about.j2')

--- a/make_index_404.py
+++ b/make_index_404.py
@@ -2,6 +2,8 @@ import os
 
 from jinja2 import Environment, select_autoescape, FileSystemLoader
 
+from slugify import slugify
+
 ENV = Environment(
     loader=FileSystemLoader([
         os.path.join(os.path.split(os.path.abspath(__file__))[0], 'templates'),
@@ -10,6 +12,7 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
 
 def make_index():
     t = ENV.get_template('index.j2')

--- a/make_nav.py
+++ b/make_nav.py
@@ -43,18 +43,14 @@ def get_territory_list(territory_key = 'country'):
         df = pd.read_csv(read_obj)
 
     if territory_key == 'country':
-        t_list = df.country.unique()
-        t_list = [w.replace('_', ' ') for w in t_list]
-        territory_list = [(t, '/countries/' + slugify(t)) for t in t_list]
+        territory_list = df.country.unique()
+        territory_list = [w.replace('_', ' ') for w in territory_list]
 
     elif territory_key == 'state':
-        t_list = df.state.unique()
-        territory_list = [(t, '/states/' + slugify(t)) for t in t_list]
+        territory_list = df.state.unique()
 
     else:
-        t_list = df.state.unique()
-        territory_list = [(t + ' Cases by County', '/counties/' + slugify(t) + '-cases') for t in t_list]
-        territory_list += [(t + ' Deaths by County', '/counties/' + slugify(t) + '-deaths') for t in t_list]
+        territory_list = df.state.unique()
 
     territory_list = sorted(territory_list)
     return territory_list

--- a/make_nav.py
+++ b/make_nav.py
@@ -20,6 +20,8 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
+
 def get_territory_list(territory_key = 'country'):
     """
     Searches .csv file and returns unique regions from region column. Creates

--- a/make_territories.py
+++ b/make_territories.py
@@ -30,7 +30,7 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
-
+ENV.filters['slugify'] = slugify
 
 def get_world_data_week():
     """

--- a/make_territories.py
+++ b/make_territories.py
@@ -153,7 +153,7 @@ def make_territories_ref_list(territory_key, territories):
     t =  t.render(title = 'By {k}'.format(k = territory_key), 
             page_title = page_title,
             page_class_attr = ["regionList", territory_key.lower()],
-            territories = [(slugify(x), x) for x in territories]
+            territories = territories
             )
     if not os.path.isdir('html_temp'):
         os.mkdir('html_temp')

--- a/sweden.py
+++ b/sweden.py
@@ -16,6 +16,8 @@ from bokeh.embed import components
 
 from jinja2 import Environment, select_autoescape, FileSystemLoader
 
+from slugify import slugify
+
 from henry_covid19 import common
 
 ENV = Environment(
@@ -25,6 +27,8 @@ ENV = Environment(
     ]),
     autoescape=select_autoescape(['html', 'xml'])
 )
+
+ENV.filters['slugify'] = slugify
 
 def get_data():
     path = common.get_data_path(os.path.abspath(os.path.dirname(__file__)), 'sweden_vs.csv')

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -9,11 +9,9 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;0,900;1,300;1,400;1,500;1,700;1,900&amp;family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&amp;display=swap">
     {% block stylesheets %}{% endblock stylesheets %}
 
-
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"
       integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
       crossorigin="anonymous"></script>
-
     <script src="/javascript/nav-submenu.js"></script>
     {%- block scripts %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bokeh/2.0.2/bokeh.min.js" integrity="sha256-q6H2tiCn/WI6/yUscC8yNCGup3XM1lizbZckx5edIl0=" crossorigin="anonymous"></script>
@@ -24,22 +22,19 @@
   <body>
 
     <header>
-
-    {%- block page_header %}
-      <div class="siteNameSlogan">
+      <div class="siteMarque">
         {% block site_name -%}
-        <div class="siteName"><a href="/" title="Covid-19 Data home">{{ site_name }}</a></div>
+        <a class="siteName" href="/" title="{{ site_name }} home">{{ site_name }}</a>
         {%- endblock site_name %}
         <span class="siteSlogan">{{ site_slogan }}</span>
+        {% include "nav.html" %}
       </div>
-      {% include "nav.html" %}
 	  {% block page_h1 %}<h1>{{ page_title }}</h1>{% endblock page_h1 %}
       {%- block last_updated %}
       {%- endblock last_updated -%}
-    {%- endblock page_header %}
     </header>
 
-    <main class="{{ page_class_attr|join(' ') }}">
+    <main class="{{ page_class_attr|join(' ') }}"> {# TODO change to xmlattr filter #}
     {% block content %}
     {% endblock content %}
     </main>
@@ -48,7 +43,7 @@
       <address>
       	<p>
         	This page is part of {{ site_name }}, a
-          {% block about_link %}<a href="/about">collaborative project</a>{% endblock about_link %}
+            {% block about_link %}<a href="/about">collaborative project</a>{% endblock about_link %}
         	created by <a href="https://github.com/paulhtremblay">Henry Tremblay</a>
         </p>
       	<p>

--- a/templates/counties.j2
+++ b/templates/counties.j2
@@ -3,7 +3,15 @@
 {# for pages showing cases/deaths in each county by state #}
 
 {% block content %}
-	<p><a href="{{link}}">{{link_name}}</a></p>
+	<p>On this page: {{ data_type }} by county </p>
+
+	<p>View
+    {%- if data_type == "Cases" %}
+	<a href="{{ state|slugify }}-deaths">Deaths by County</a>
+    {%- else %}
+	<a href="{{ state|slugify }}-cases">Cases by County</a>
+    {%- endif %}
+    </p>
 
 	{{div|safe}}
 

--- a/templates/counties_ref.j2
+++ b/templates/counties_ref.j2
@@ -4,9 +4,9 @@
       <ul>
         {%- for t in territories %}
         <li>
-          {{ t[1] }}
-            <a href="{{ t[0]}}-cases" title="{{ t[1] }} Cases">Cases</a>
-            <a href="{{ t[0]}}-deaths" title="{{ t[1] }} Deaths">Deaths</a>
+          {{ t }}
+            <a href="{{ t|slugify }}-cases" title="{{ t }} Cases">Cases</a>
+            <a href="{{ t|slugify }}-deaths" title="{{ t }} Deaths">Deaths</a>
         </li>
         {%- endfor %}
       </ul>

--- a/templates/data_table.j2
+++ b/templates/data_table.j2
@@ -39,7 +39,7 @@
             <tr>
   					{% for cell in row -%}
 						  {%- if loop.index == 1 -%}
-              <th>{{cell}}</th>
+              <th><a href="{{cell|slugify}}">{{cell}}</a></th>
               {% else -%}
               <td>{{cell}}</td>
               {% endif -%}

--- a/templates/index.j2
+++ b/templates/index.j2
@@ -12,8 +12,21 @@
 
         {{div|safe}}
 
-      <p>
-        Graphs showing trends in Covid-19 infection, deaths, and rates
-        in the <abbr title="United States">U.S.</abbr> and world.
-      </p>
+        <p>
+            Number of Covid-19 infections and deaths
+            in the <abbr title="United States">U.S.</abbr> and world,
+            in graphs and tables.
+        </p>
+        <p>
+            Quick links:
+        </p>
+        <ul>
+            <li><a href="/countries/united-states-of-america">United States</a></li>
+            <li><a href="/sweden-vs-other">Sweden Compared With Other Countries</a></li>
+            <li><a href="/countries/">List of Countries</a></li>
+            <li><a href="/states/">List of states in the U.S.</a></li>
+            <li><a href="/states/table-cases">Table of Cases in U.S. States</a></li>
+            <li><a href="/states/table-deaths">Table of Deaths in U.S. States</a></li>
+        </ul>
+
 {% endblock content %}

--- a/templates/javascript/nav-submenu.js
+++ b/templates/javascript/nav-submenu.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
-  // opens and closes submenus with country/state lists in main <nav> when user clicks icon
-  // opens filtered search results list when search input is focussed and contains text
+  // opens and closes submenus with country/state lists in main <nav> when user clicks icon;
+  // opens filtered search results list when search input has focus and contains text
 
   var targetSubMenu, searchText, regionName;
 
@@ -11,18 +11,18 @@ $(document).ready(function(){
 
   // create submenu container, add label (for input element), and
   // insert it in main page nav after other li.submenu elements
-  $('<li class="hasSubmenu"></li>')
+  $('<li class="hasSubmenu searchWidget"></li>')
     .append('<label title="search for a country or state"></label>')
-    .append('<ul class="submenu searchResults" hidden></ul>')
-    .insertAfter('.lastRegionContainer');
+    .append('<output><ul class="submenu" hidden></ul></output>')
+    .appendTo('body > header > div > nav > ul');
 
   // append svg search icon and input element to label
   $('.hasSubmenu > label')
     .append('<svg viewBox="0 0 250 450"><title>search</title><g stroke-width="30"><circle cx="130" cy="120" r="100" /><line x1="130" y1="220" x2="130" y2="270" /></g><g stroke-width="43"><line x1="130" y1="273" x2="130" y2="370" /><line x1="130" y1="330" x2="130" y2="425" stroke-linecap="round" /></g></svg>')
     .append('<input type="search" size="14">');
 
-  // add all region page links to ul.searchResults
-  $('.regions > li').clone().appendTo('.searchResults');
+  // add all region page links to output ul search results
+  $('.regions > li').clone().appendTo('output > ul.submenu');
   // TODO improve clone, maybe clone entire ul element then flatten instead of cloning each li element
 
 
@@ -58,31 +58,31 @@ $(document).ready(function(){
     // if there are characters in the input
     closeSubmenus();
     if ($.trim(this.value)) {
-      $('.searchResults').slideDown(300);
+      $('output > .submenu').slideDown(300);
     }
   });
 
 
   $('.hasSubmenu > label > input').on('input', function(){
-    // on input to search form, show filtered .searchResults matching
-    // any text entered or hide .searchResults if field is empty
+    // on input to search form, show filtered li elements matching
+    // any text entered, or hide output ul if field is empty
 
     searchText = $.trim(this.value).toLowerCase();
 
     if (searchText) {
-      // filter .searchResults based on text entered in input
-      $('.searchResults > li').each(function(){
+      // filter search results based on text entered in input
+      $('output > .submenu > li').each(function(){
         regionName = $(this).text().toLowerCase();
         (regionName.indexOf(searchText) >= 0) ? $(this).show() : $(this).hide();
       });
-      // show ul.searchResults
-      if ($('.searchResults').is(':hidden')) {
-        $('.searchResults').slideDown(300);
+      // show search results output ul.submenu
+      if ($('output > .submenu').is(':hidden')) {
+        $('output > .submenu').slideDown(300);
       }
     }
     else {
-      // input is empty, so hide ul.searchResults
-      $('.searchResults').hide();
+      // input is empty, so hide search results output ul.submenu
+      $('output > .submenu').hide();
     }
   });
 

--- a/templates/nav.j2
+++ b/templates/nav.j2
@@ -12,8 +12,6 @@
           <li class="hasSubmenu">
             <a href="/states/">U.S. States</a>
             <ul class="submenu regions" hidden>
-              <li><a href="/states/table-cases">Table of Cases</a></li>
-              <li><a href="/states/table-deaths">Table of Deaths</a></li>
               {%- for s in states %}
               <li><a href="/states/{{ s|slugify }}">{{ s }}</a></li>
               {%- endfor %}
@@ -28,8 +26,5 @@
               {%- endfor %}
             </ul>
           </li>
-          <li><a href="/states-cases">Cases Over Time</a></li>
-          <li><a href="/states-deaths">Deaths Over Time</a></li>
-          <li><a href="/sweden-vs-other">Sweden Comparison</a></li>
         </ul>
       </nav>

--- a/templates/nav.j2
+++ b/templates/nav.j2
@@ -10,7 +10,7 @@
             </ul>
           </li>
           <li class="hasSubmenu">
-            <a href="/states/">U.S. States</a>
+            <a href="/states/"><abbr title="United States">U.S.</abbr> States</a>
             <ul class="submenu regions" hidden>
               {%- for s in states %}
               <li><a href="/states/{{ s|slugify }}">{{ s }}</a></li>
@@ -18,7 +18,7 @@
             </ul>
           </li>
           <li class="hasSubmenu lastRegionContainer">
-            <a href="/counties/">Counties</a>
+            <a href="/counties/"><abbr title="United States">U.S.</abbr> Counties</a>
             <ul class="submenu regions county" hidden>
               {%- for ct in counties %}
               <li><a href="/counties/{{ ct|slugify }}-cases">{{ ct }} Cases by County</a></li>

--- a/templates/nav.j2
+++ b/templates/nav.j2
@@ -5,7 +5,7 @@
             <a href="/countries/">Countries</a>
             <ul class="submenu regions" hidden>
               {%- for c in countries %}
-              <li><a href="{{ c[1] }}">{{ c[0] }}</a></li>
+              <li><a href="/countries/{{ c|slugify }}">{{ c }}</a></li>
               {%- endfor %}
             </ul>
           </li>
@@ -13,7 +13,7 @@
             <a href="/states/">U.S. States</a>
             <ul class="submenu regions" hidden>
               {%- for s in states %}
-              <li><a href="{{ s[1] }}">{{ s[0] }}</a></li>
+              <li><a href="/states/{{ s|slugify }}">{{ s }}</a></li>
               {%- endfor %}
             </ul>
           </li>
@@ -21,7 +21,8 @@
             <a href="/counties/">Counties</a>
             <ul class="submenu regions county" hidden>
               {%- for ct in counties %}
-              <li><a href="{{ ct[1] }}">{{ ct[0] }}</a></li>
+              <li><a href="/counties/{{ ct|slugify }}-cases">{{ ct }} Cases by County</a></li>
+              <li><a href="/counties/{{ ct|slugify }}-deaths">{{ ct }} Deaths by County</a></li>
               {%- endfor %}
             </ul>
           </li>

--- a/templates/nav.j2
+++ b/templates/nav.j2
@@ -1,30 +1,30 @@
-<nav>
-        <ul>
-          <li><a href="/">Home</a></li>
-          <li class="hasSubmenu">
-            <a href="/countries/">Countries</a>
-            <ul class="submenu regions" hidden>
-              {%- for c in countries %}
-              <li><a href="/countries/{{ c|slugify }}">{{ c }}</a></li>
-              {%- endfor %}
+          <nav>
+            <ul>
+              <li><a href="/">Home</a></li>
+              <li class="hasSubmenu">
+                <a href="/countries/">Countries</a>
+                <ul class="submenu regions" hidden>
+                  {%- for c in countries %}
+                  <li><a href="/countries/{{ c|slugify }}">{{ c }}</a></li>
+                  {%- endfor %}
+                </ul>
+              </li>
+              <li class="hasSubmenu">
+                <a href="/states/"><abbr title="United States">U.S.</abbr> States</a>
+                <ul class="submenu regions" hidden>
+                  {%- for s in states %}
+                  <li><a href="/states/{{ s|slugify }}">{{ s }}</a></li>
+                  {%- endfor %}
+                </ul>
+              </li>
+              <li class="hasSubmenu lastRegionContainer">
+                <a href="/counties/"><abbr title="United States">U.S.</abbr> Counties</a>
+                <ul class="submenu regions county" hidden>
+                  {%- for ct in counties %}
+                  <li><a href="/counties/{{ ct|slugify }}-cases">{{ ct }} Cases by County</a></li>
+                  <li><a href="/counties/{{ ct|slugify }}-deaths">{{ ct }} Deaths by County</a></li>
+                  {%- endfor %}
+                </ul>
+              </li>
             </ul>
-          </li>
-          <li class="hasSubmenu">
-            <a href="/states/"><abbr title="United States">U.S.</abbr> States</a>
-            <ul class="submenu regions" hidden>
-              {%- for s in states %}
-              <li><a href="/states/{{ s|slugify }}">{{ s }}</a></li>
-              {%- endfor %}
-            </ul>
-          </li>
-          <li class="hasSubmenu lastRegionContainer">
-            <a href="/counties/"><abbr title="United States">U.S.</abbr> Counties</a>
-            <ul class="submenu regions county" hidden>
-              {%- for ct in counties %}
-              <li><a href="/counties/{{ ct|slugify }}-cases">{{ ct }} Cases by County</a></li>
-              <li><a href="/counties/{{ ct|slugify }}-deaths">{{ ct }} Deaths by County</a></li>
-              {%- endfor %}
-            </ul>
-          </li>
-        </ul>
-      </nav>
+          </nav>

--- a/templates/nav.j2
+++ b/templates/nav.j2
@@ -12,6 +12,8 @@
           <li class="hasSubmenu">
             <a href="/states/">U.S. States</a>
             <ul class="submenu regions" hidden>
+              <li><a href="/states/table-cases">Table of Cases</a></li>
+              <li><a href="/states/table-deaths">Table of Deaths</a></li>
               {%- for s in states %}
               <li><a href="/states/{{ s|slugify }}">{{ s }}</a></li>
               {%- endfor %}
@@ -29,7 +31,5 @@
           <li><a href="/states-cases">Cases Over Time</a></li>
           <li><a href="/states-deaths">Deaths Over Time</a></li>
           <li><a href="/sweden-vs-other">Sweden Comparison</a></li>
-          <li><a href="/table-data-cases">Table of Cases</a></li>
-          <li><a href="/table-data-deaths">Table of Deaths</a></li>
         </ul>
       </nav>

--- a/templates/states.j2
+++ b/templates/states.j2
@@ -1,0 +1,17 @@
+{% extends "data.j2" %}
+
+{% block content %}
+
+{# page_title in by_states.py is state name #}
+	<ul>
+		<li>
+			<a href="/counties/{{ page_title|slugify }}-cases">{{ page_title }} Cases by County</a>
+		</li>
+		<li>
+			<a href="/counties/{{ page_title|slugify }}-deaths">{{ page_title }} Deaths by County</a>
+		</li>
+	</ul>
+
+	{{div|safe}}
+
+{% endblock %}

--- a/templates/states_ref.j2
+++ b/templates/states_ref.j2
@@ -1,0 +1,16 @@
+{% extends "data.j2" %}
+
+{% block content %}
+
+        <p><a href="/states/table-cases">Cases Per State—Table</a></p>
+
+        <p><a href="/states/table-deaths">Deaths Per State—Table</a></p>
+
+        <ul>
+            {% for t in territories %}
+            <li><a href="{{ t|slugify }}">{{ t }}</a></li>
+            {% endfor %}
+        </ul>
+
+	<p><a href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'>Washington by RT</a>
+{% endblock %}

--- a/templates/styles/site.css
+++ b/templates/styles/site.css
@@ -221,7 +221,8 @@ li.hasSubmenu {
 @media screen and (min-width: 40em) {
 
   nav > ul {
-    justify-content: space-around;
+    justify-content: space-between;
+    max-width: 60em;
   }
 
 }

--- a/templates/styles/site.css
+++ b/templates/styles/site.css
@@ -1,16 +1,16 @@
 /* site wide styles for covid 19 data site */
 
 html {
-  --pageBackground: #fff;
   --bleedPadding: .5rem;
-  --bleedMargin: -.5rem;
+  --bleedMargin: -.4rem;
   --bloodRed: rgb(155, 17, 28);
   --golden: #ffdc00;
   --brightYellow: #ffff00;
 }
 
 header {
-  --txtColor: #ffdc00;
+  --txtColor: var(--golden);
+  --bgColor: var(--bloodRed);
 }
 
 body {
@@ -22,36 +22,70 @@ body {
 footer {
   margin-top: 4em;
 }
+
 body > header > nav,
-.siteNameSlogan {
+.siteMarque {
   margin-left: var(--bleedMargin);
   margin-right: var(--bleedMargin);
   padding-left: var(--bleedPadding);
   padding-right: var(--bleedPadding);
 }
 
+.siteMarque {
+  padding-top: .66em;
+}
+
+a.siteName,
+h1.siteName,
+.siteMarque,
+nav > ul > li > a {
+  color: var(--txtColor);
+  background-color: var(--bgColor);
+}
 
 h1 {
+  /* for h1 elements except h1.siteName on home page */
   color: var(--bloodRed);
-  background-color: var(--pageBackground);
+  background-color: white;
 }
 
-h1.siteName,
-nav,
-.siteNameSlogan {
-  color: var(--txtColor);
-  background-color: var(--bloodRed);
-}
-
-.siteNameSlogan {
-  padding-top: .68em;
-  padding-bottom: .66em;
+h1.siteName {
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 nav {
-  padding-top: 1px;
-  padding-bottom: .1em;
+  padding-bottom: 1px;
   font-size: 110%;
+}
+
+.home > article > h1,
+.siteName {
+  font-size: 200%;
+  font-weight: bold;
+}
+
+.siteSlogan {
+  font-size: 160%;
+  font-weight: bold;
+}
+
+nav > ul > li > label > input {
+  font-size: 90%;
+  width: 9em;
+}
+
+nav > ul > li > a {
+  padding: .5em;
+}
+
+nav > ul > li > svg {
+  padding: .3em;
+}
+
+.hasSubmenu svg  {
+  stroke: var(--txtColor);
+  fill: var(--bgColor);
 }
 
 a:hover {
@@ -60,62 +94,11 @@ a:hover {
   text-decoration: none;
 }
 
-.home > article > h1,
-.siteName, .siteSlogan {
-  font-size: 200%;
-  font-weight: bold;
-}
-
-.siteName > a,
-nav > ul > li > a {
-  color: var(--golden);
-  background-color: var(--bloodRed);
-}
-
-nav > ul > li > label > input {
-  font-size: 90%;
-  width: 9em;
-}
-
-nav > ul > li > a,
-nav > ul > li > svg {
-  padding: .5em;
-}
-
-.hasSubmenu > svg:hover,
-nav > ul > li > a:hover,
-.siteName > a:hover {
-  color: var(--bloodRed);
-  stroke: var(--bloodRed);
-  background-color: var(--golden);
-}
-
-.siteName > a {
-  text-decoration: none;
-}
-
-nav > ul {
-  line-height: 2.4em;
-}
-
-.submenu {
-  line-height: 1.2em;
-  font-size: 1rem;
-}
-
 .hasSubmenu svg {
   vertical-align: middle;
-  stroke: var(--golden);
-}
-
-.hasSubmenu > svg {
-  height: 1.5em;
-  width: 1.3em;
-  margin-left: -.3em;
 }
 
 .hasSubmenu > label > svg {
-  fill: var(--bloodRed);
   height: 2.5em;
   width: auto;
   transform: rotate(40deg);
@@ -123,8 +106,27 @@ nav > ul {
   margin-left: .1em;
 }
 
-svg.open {
-  transform: rotate(180deg);
+a.siteName:hover,
+.hasSubmenu > svg:hover,
+nav > ul > li > a:hover {
+  /* reverse color on nav :hover */
+  color: var(--bgColor);
+  stroke: var(--bgColor);
+  background-color: var(--txtColor);
+}
+
+a.siteName {
+  text-decoration: none;
+}
+
+nav > ul {
+  line-height: 2.4em;
+}
+
+.hasSubmenu > label,
+.hasSubmenu > output,
+ .submenu {
+  display: none;
 }
 
 ul.contributors > li {
@@ -132,69 +134,140 @@ ul.contributors > li {
   margin-bottom: .5em;
 }
 
-nav > ul > li > a,
-nav > ul > li > ul > li > a {
+nav > ul > li > ul > li > a,
+nav > ul > li > output > ul > li > a {
   padding: .3em;
 }
 
-li.hasSubmenu {
-  position: relative;
+h1.siteName {
+    padding-bottom: 0;
+    margin-border: 0;
 }
 
-.submenu {
-  position: absolute;
-  left: 0;
-  top: 3em;
-  margin-left: 0;
-  padding-left: 0;
-  max-height: 30em;
-  max-height: 80vh;
-  overflow-y: scroll;
-  list-style: none;
-  color: black;
-  background-color: white;
-  z-index: 10;
-  display: none;
-  box-shadow: .3em -0.1em .5em var(--bloodRed)
+@media screen and (width < 31em) {
+
+  header {
+    text-align: center;
+  }
+
+  nav > ul {
+    width: 13em;
+    margin-left: auto;
+    margin-right: auto;
+    list-style: none;
+    line-height: 1.5em;
+  }
+
+  nav > ul > li > a {
+    display: block;
+    border: 1px solid;
+    border-top: none;
+  }
+
+  nav > ul > li:first-child > a {
+    border-top: 1px solid;
+  }
+
+  nav > ul > li > svg,
+  .siteSlogan {
+    display: none;
+  }
+
+  .submenu {
+    display: none;
+  }
 }
 
-.lastRegionContainer + .hasSubmenu > .submenu {
-  left: 2em;
-}
+@media screen and (min-width: 31em) {
 
-.submenu > li {
-  min-width: 12em;
-}
-
-.submenu > li > a {
-  display: block;
-  white-space: nowrap;
-  border-left: 1px solid var(--bloodRed);
-  border-bottom: 1px solid var(--bloodRed);
-  border-right: 1px solid var(--bloodRed);
-  padding-top: .4em;
-  padding-bottom: .4em;
-}
-
-.submenu.county > li:nth-child(odd) > a {
-  border-top: 1px solid var(--bloodRed);
-}
-
-
-
-@media screen and (width < 20em) {
+  nav > ul {
+    margin-left: 0;
+    padding-left: 0;
+  }
 
   nav > ul > li {
-    margin-bottom: .5em;
+    display: inline-block;
   }
 
   .siteSlogan {
     display: none;
   }
 
+    .submenu {
+      line-height: 1.2em;
+      font-size: 1rem;
+    }
+
+    .hasSubmenu > svg {
+      height: 1.5em;
+      width: 1.3em;
+      margin-left: -.3em;
+    }
+
+    .hasSubmenu > label,
+    .hasSubmenu > output {
+      display: unset;
+    }
+
+    svg.open {
+      transform: rotate(180deg);
+    }
+
+    li.hasSubmenu {
+      position: relative;
+    }
+
+    .submenu {
+      position: absolute;
+      left: 0;
+      top: 3em;
+      margin-left: 0;
+      padding-left: 0;
+      max-height: 30em;
+      max-height: 80vh;
+      overflow-y: scroll;
+      list-style: none;
+      color: black;
+      background-color: white;
+      z-index: 10;
+      display: none;
+      box-shadow: .3em -0.1em .5em var(--bgColor);
+    }
+
+    .hasSubmenu > output > .submenu {
+      left: 2em;
+    }
+
+    .submenu > li {
+      min-width: 12em;
+    }
+
+    .submenu > li > a {
+      display: block;
+      white-space: nowrap;
+      border-left: 1px solid var(--bgColor);
+      border-bottom: 1px solid var(--bgColor);
+      border-right: 1px solid var(--bgColor);
+      padding-top: .4em;
+      padding-bottom: .4em;
+    }
+
+    .submenu.county > li:nth-child(odd) > a {
+      border-top: 1px solid var(--bloodRed);
+    }
+
+
 }
 
-@media screen and (min-width: 20em) {
+@media screen and (min-width: 33em) {
+
+  .siteSlogan {
+    display: block;
+  }
+
+}
+
+@media screen and (min-width: 35em) {
 
   nav > ul {
     margin-left: 0;
@@ -203,17 +276,23 @@ li.hasSubmenu {
     flex-flow: wrap;
   }
 
-  nav > ul > li {
-    display: inline-block;
-  }
+}
 
-  .siteName,
-  .siteSlogan {
+@media screen and (min-width: 55em) {
+
+  h1.siteName, .siteSlogan {
     display: inline;
   }
 
   .siteName:after {
     content: ": ";
+    color: var(--txtColor);
+    background-color: var(--bgColor);
+  }
+
+  .siteSlogan {
+    font-size: 200%;
+    font-weight: bold;
   }
 
 }
@@ -247,6 +326,42 @@ li.hasSubmenu {
   margin-left: 0;
   padding-left: 0;
 }
+
+@media (min-width: 40em) {
+
+  .home {
+    font-size: 110%;
+  }
+
+}
+
+@media (min-width: 60em) {
+
+  .home {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    grid-template-rows: auto auto;
+    column-gap: 3em;
+  }
+
+  .home > p:first-child {
+    grid-row: 1/-1;
+  }
+
+  .home > p:nth-child(2) {
+    margin-bottom: 0;
+  }
+
+  .home > ul {
+    margin-left: 0;
+    padding-left: 1em;
+  }
+
+  .home > ul > li {
+    margin-bottom: .3em;
+  }
+}
+
 
 td {
   font-family: "Roboto Mono", monospace;

--- a/templates/styles/site.css
+++ b/templates/styles/site.css
@@ -132,7 +132,8 @@ ul.contributors > li {
   margin-bottom: .5em;
 }
 
-ul > li > a {
+nav > ul > li > a,
+nav > ul > li > ul > li > a {
   padding: .3em;
 }
 

--- a/templates/territories_ref.j2
+++ b/templates/territories_ref.j2
@@ -3,7 +3,7 @@
 {% block content %}
       <ul>
         {% for t in territories %}
-		    <li><a href="{{ t[0]}}">{{ t[1] }}</a></li>
+		    <li><a href="{{ t|slugify }}">{{ t }}</a></li>
         {% endfor %}
       </ul>
 	<p><a href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'>Washington by RT</a>

--- a/templates/territories_ref.j2
+++ b/templates/territories_ref.j2
@@ -1,6 +1,13 @@
 {% extends "data.j2" %}
 
 {% block content %}
+
+        <p>
+            Choose a country in the list below to see graphs for that country.
+            You can also look at
+            <a href="/sweden-vs-other">Sweden Compared With Other Countries</a>.
+        </p>
+
       <ul>
         {% for t in territories %}
 		    <li><a href="{{ t|slugify }}">{{ t }}</a></li>

--- a/us_states_rates.py
+++ b/us_states_rates.py
@@ -15,6 +15,8 @@ from bokeh.embed import components
 
 from jinja2 import Environment, select_autoescape, FileSystemLoader
 
+from slugify import slugify
+
 from henry_covid19 import common
 
 DIR = os.path.split(os.path.abspath(__file__))[0]
@@ -27,6 +29,7 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
 
 """
 makes graphs for rates of states compared to US

--- a/us_states_rt.py
+++ b/us_states_rt.py
@@ -18,6 +18,8 @@ from bokeh.embed import components
 
 from jinja2 import Environment, select_autoescape, FileSystemLoader
 
+from slugify import slugify
+
 from henry_covid19 import common
 from henry_covid19.states_data import us_states_list as states_list
 
@@ -31,6 +33,7 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
 
 def get_state_data(test = False):
   if test:

--- a/washington_state.py
+++ b/washington_state.py
@@ -15,6 +15,8 @@ from bokeh.embed import components
 
 from jinja2 import Environment, select_autoescape, FileSystemLoader
 
+from slugify import slugify
+
 from henry_covid19 import common
 
 ENV = Environment(
@@ -25,6 +27,7 @@ ENV = Environment(
     autoescape=select_autoescape(['html', 'xml'])
 )
 
+ENV.filters['slugify'] = slugify
 
 """
 makes bar graphs for deaths/cases for WA and by counties


### PR DESCRIPTION
Simplifies main page navigation to just 4 links plus the search widget. The other links are moved to the home page, the /states/ page, and the /countries/ page, as appropriate.