### PR TITLE
Changes homepage layout

### DIFF
--- a/templates/index.j2
+++ b/templates/index.j2
@@ -9,25 +9,33 @@
 {%- block page_h1 -%}{%- endblock page_h1 -%}
 
 {% block content %}
-
-
         <p>
             Number of Covid-19 infections and deaths
             in the <abbr title="United States">U.S.</abbr> and world,
             in graphs and tables.
         </p>
-		<h3>Graph of the Day</h3>
-        {{div|safe}}
-		{{text_commentary|safe}}
-        <p>
-            Quick links:
-        </p>
-        <ul>
-            <li><a href="/countries/united-states-of-america">United States</a></li>
-            <li><a href="/countries/">List of countries</a></li>
-            <li><a href="/states/">List of states in the U.S.</a></li>
-            <li><a href="/states/table-cases">Table of cases in U.S. states</a></li>
-            <li><a href="/states/table-deaths">Table of deaths in U.S. states</a></li>
-        </ul>
+
+        {% if div is defined and div|length %}
+        <article>
+
+    		<h1>Graph of the Day</h1>
+
+            {{div|safe}}
+
+    	    <p>
+    	        {{text_commentary|safe}}
+    	    </p>
+
+	    </article>
+	    {% endif %}
+
+        <section>
+            <h1>Quick links:</h1>
+            <ul>
+                <li><a href="/countries/united-states-of-america">United States</a></li>
+                <li><a href="/states/table-cases">Table of cases in U.S. states</a></li>
+                <li><a href="/states/table-deaths">Table of deaths in U.S. states</a></li>
+            </ul>
+	    </section>
 
 {% endblock content %}

--- a/templates/styles/site.css
+++ b/templates/styles/site.css
@@ -111,6 +111,7 @@ nav {
 }
 
 .home > article > h1,
+.home > section > h1,
 .siteName {
   font-size: 200%;
   font-weight: bold;
@@ -410,37 +411,10 @@ h1.siteName {
 
 @media (min-width: 40em) {
 
-  .home {
+  .home > p:first-child {
     font-size: 110%;
   }
 
-}
-
-@media (min-width: 60em) {
-
-  .home {
-    display: grid;
-    grid-template-columns: 1fr 2fr;
-    grid-template-rows: auto auto;
-    column-gap: 3em;
-  }
-
-  .home > p:first-child {
-    grid-row: 1/-1;
-  }
-
-  .home > p:nth-child(2) {
-    margin-bottom: 0;
-  }
-
-  .home > ul {
-    margin-left: 0;
-    padding-left: 1em;
-  }
-
-  .home > ul > li {
-    margin-bottom: .3em;
-  }
 }
 
 


### PR DESCRIPTION
Moves graph of the day into an article element,
with a scoped h1 element. Puts text_commentary
in a p element. Uses if in index.j2 so that
markup is only rendered if there’s data to show.

Removes grid layout from css for home page.

Resolves layout problem in issue #69 by removing
grid layout. TODO: create a better homepage layout
on widescreens.

NB: I can only check this without the graph of the
day (cf. issue #36), so I did not upload this to the
dev bucket.